### PR TITLE
Fix wrong url in launcher icon

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,7 @@
   <title></title>
 </head>
 <body>
-<a href="https://super-productivity.com/app"
+<a href="https://app.super-productivity.com"
    target="_blank">
   <img src="img/icon_128x128.png">
 </a>


### PR DESCRIPTION
# Description

This changes the target URL in the chrome extension from https://super-productivity.com/app to https://app.super-productivity.com

## Issues Resolved

None found